### PR TITLE
Fix no set on empty list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mo linguist-vendored

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/LudovicTOURMAN/hclq/query"
+	"github.com/mattolenik/hclq/query"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/LudovicTOURMAN/hclq/query"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/hcl/hcl/token"
 	jsonParser "github.com/hashicorp/hcl/json/parser"
+	"github.com/mattolenik/hclq/query"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
Using this terraform sample `bar.tf`:
```terraform
module "bar" {
  source = "../modules/foo"
  my_list = []
}
```
Running command `cat bar.tf | hclq set 'module.bar.my_list[]' '["foo","bar"]'` will result in not changing the value in the file/output.

This is caused by the fact that list is empty and we don't return a `Result` struct containing the concerned ast.Node