### PR TITLE
fixing #6. Drop the shorthand to resolve panic

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -126,7 +126,7 @@ func getTokenType(val string) token.Type {
 }
 
 func init() {
-	SetCmd.PersistentFlags().BoolVarP(&config.ModifyInPlace, "in-place", "i", false, "edit the input file in-place rather than printing to stdout, conflicts with --out")
+	SetCmd.PersistentFlags().BoolVarP(&config.ModifyInPlace, "in-place", "", false, "edit the input file in-place rather than printing to stdout, conflicts with --out")
 	SetCmd.AddCommand(AppendCmd)
 	SetCmd.AddCommand(PrependCmd)
 	SetCmd.AddCommand(ReplaceCmd)


### PR DESCRIPTION
remove the shorthand so it doesn't conflict with the global option.
fixes #6 