### PR TITLE
acutally read the -d DESTINATION and -a ARCH arguments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ platform_check() {
 main() {
   platform_check
 
-  while getopts ":qhdao:" opt; do
+  while getopts ":qhd:a:o:" opt; do
     case $opt in
       q) QUIET=true ;;
       d) DESTINATION="$OPTARG" ;;


### PR DESCRIPTION
Needed trailing colon (:) for those args.